### PR TITLE
Connector execution

### DIFF
--- a/app/dao/mapperDAO.js
+++ b/app/dao/mapperDAO.js
@@ -9,9 +9,16 @@
 
       this.public = {
         create: function createMap(name, maps) {
+          var filledMaps = [];
+          maps.forEach(function checkMap(map) {
+            console.log(map);
+            if (!!map.place && !!map.source && !!map.destination) {
+              this.push(map);
+            }
+          }, filledMaps);
           return this.private.request('POST', '/api/mappers/', {
             name: name,
-            maps: maps
+            maps: filledMaps
           });
         },
         getAll: function getAll() {

--- a/app/viewModels/mapperC.js
+++ b/app/viewModels/mapperC.js
@@ -7,8 +7,12 @@
     $scope.name = null;
     $scope.maps = [];
 
+    $scope.openPlaces = false;
+    $scope.availablePlaces = ['url', 'header', 'data'];
+
     $scope.addMap = function addMap() {
       $scope.maps.push({
+        place: null,
         source: null,
         destination: null
       });
@@ -28,6 +32,18 @@
           $scope.maps = [];
           $scope.addMap();
         });
+    };
+
+    // Select place
+    $scope.selectPlace = function selectPlace(map, place) {
+      var index = $scope.maps.indexOf(map);
+      $scope.maps[index].place = place;
+      $scope.openPlaces = false;
+    };
+
+    // Open th dropdown for places.
+    $scope.togglePlacesDropdown = function togglePlacesDropdown() {
+      $scope.openPlaces = !$scope.openPlaces;
     };
   });
 }(window.angular));

--- a/app/widgets/mapperRegistrator/mapperRegistrator.html
+++ b/app/widgets/mapperRegistrator/mapperRegistrator.html
@@ -39,6 +39,7 @@
     </section>
     <md-button class="md-primary md-raised"
                aria-label="save map"
+               type="submit"
                ng-click="save()">
       save
     </md-button>

--- a/app/widgets/mapperRegistrator/mapperRegistrator.html
+++ b/app/widgets/mapperRegistrator/mapperRegistrator.html
@@ -12,7 +12,20 @@
     <md-text-float label="Mapper name"
                    ng-model="name"></md-text-float>
     <section ng-repeat="map in maps"
+             class="row"
              layout="row">
+      <div layout="column">
+        <md-text-float label="place"
+                     ng-model="map.place"
+                     data-ng-click="togglePlacesDropdown()"></md-text-float>
+        <md-list ng-show="openPlaces">
+          <md-item ng-repeat="place in availablePlaces"
+                   data-ng-click="selectPlace(map, place)">
+            <p>{{ place }}</p>
+            <md-divider ng-if="!$last"></md-divider>
+          </md-item>
+        </md-list>
+      </div>
       <md-text-float label="source"
                      ng-model="map.source"></md-text-float>
       <md-text-float label="destination"

--- a/app/widgets/mapperRegistrator/mapperRegistrator.js
+++ b/app/widgets/mapperRegistrator/mapperRegistrator.js
@@ -15,7 +15,7 @@
 
         scope.$watch('maps', function autoAdd(newMaps) {
           var lastMap = newMaps[newMaps.length - 1];
-          if (!!lastMap.source && !!lastMap.destination) {
+          if (!!lastMap.place && !!lastMap.source && !!lastMap.destination) {
             scope.addMap();
           }
         }, true);

--- a/app/widgets/mapperRegistrator/mapperRegistrator.less
+++ b/app/widgets/mapperRegistrator/mapperRegistrator.less
@@ -1,3 +1,18 @@
 mapper-registrator {
-    
+  md-list {
+    margin-left: 30px;
+    margin-right: 10px;
+    margin-top: 0px;
+
+    md-item:hover {
+      color: #00bcd4;
+      cursor: pointer;
+    }
+
+    p {
+      line-height: 1;
+      font-size: small;
+      margin: 2px;
+    }
+  }
 }

--- a/app/widgets/selector/selector.html
+++ b/app/widgets/selector/selector.html
@@ -6,8 +6,9 @@
 <md-text-float label="{{ label }}"
                ng-model="displayValue"
                ng-click="openOptions()"></md-text-float>
-<md-whiteframe class="md-whiteframe-z5">
-  <md-list ng-show="isOpen">
+<md-whiteframe class="md-whiteframe-z5"
+               ng-show="isOpen">
+  <md-list>
     <md-item flex ng-repeat="option in options"
              ng-click="select(option)">
       <ng-transclude></ng-transclude>

--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
       "inflate": true,
       "limit": "5mb",
       "type": "json"
-    }
+    },
+    "strictSSL": "false"
   },
   "mongoDb": {
     "uri": "mongodb://localhost:27017/conRest",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "should": "^4.1.0",
     "sinon": "^1.11.1",
     "tmp": "0.0.23",
-    "underscore": "~1.6.0",
     "yadda": "^0.11.4"
   },
   "engines": {
@@ -77,7 +76,8 @@
   },
   "repository": "ssh://git@github.com:EnoF/con-rest.git",
   "dependencies": {
+    "nock": "~0.48.2",
     "request": "~2.47.0",
-    "nock": "~0.48.2"
+    "underscore": "~1.6.0"
   }
 }

--- a/server/api.js
+++ b/server/api.js
@@ -172,7 +172,7 @@
       agentOptions: {
         ca: config.getCertificates()
       },
-      strictSSL: false
+      strictSSL: config.getSSLConfig()
     };
 
     var type = apiCall.type || null;

--- a/server/api.js
+++ b/server/api.js
@@ -142,7 +142,7 @@
         res.send(data);
         return data;
       }, function error(err) {
-        res.status(500).send(err);
+        res.status(500).send(err.toString());
         throw err;
       });
   }

--- a/server/api.js
+++ b/server/api.js
@@ -171,7 +171,8 @@
       headers: headers,
       agentOptions: {
         ca: config.getCertificates()
-      }
+      },
+      strictSSL: false
     };
 
     var type = apiCall.type || null;

--- a/server/api.js
+++ b/server/api.js
@@ -222,6 +222,7 @@
       deferred.resolve({
         statusCode: response.statusCode,
         apiCall: apiCall,
+        url: apiCall.url,
         response: parsedBody,
         headers: options.headers,
         type: options.type,

--- a/server/connector.js
+++ b/server/connector.js
@@ -3,7 +3,7 @@
 //
 // Author: Dominik Kukacka
 // Fork me on Github: https://github.com/EnoF/con-rest
-(function connectorScope(mongoose, queue, Workflow, Connector) {
+(function connectorScope(mongoose, queue, _, Workflow, Connector, mapper) {
   'use strict';
 
   function addConnectorToWorkflow(req, res) {
@@ -107,16 +107,59 @@
       });
   }
 
+  function executeConnector(workflow, callTo, callResults) {
+    return function(callFrom) {
+      if(callFrom) {
+        var connector = null;
+
+        for (var i = 0; i < workflow.connectors.length; i++) {
+          connector = workflow.connectors[i];
+          var result = callResults[connector.source.toString()];
+          if(!!result && connector.destination.toString() === callTo.id.toString()) {
+            var mappedValues = mapper.map(result.response, connector.mapper);
+            modifyCall(callTo, mappedValues);
+          }
+        }
+      }
+      return callTo;
+    };
+  }
+
+  function modifyCall(call, mappedValues) {
+    for (var i = 0; i < mappedValues.length; i++) {
+      var mappedValue = mappedValues[i];
+      switch(mappedValue.place) {
+        case 'url':
+          var regex = new RegExp(mappedValue.destination, 'g');
+          var url = call.url.replace(regex, mappedValue.value);
+          call.url = url;
+          break;
+
+        case 'header':
+          var obj = {};
+          obj[mappedValue.destination] = mappedValue.value;
+          if(!call.headers) {
+            call.headers = {};
+          }
+          call.headers = _.extend(call.headers, obj);
+          break;
+      }
+    }
+  }
+
   module.exports = {
     getConnectorById: getConnectorById,
     getConnectorsByWorkflowId: getConnectorsByWorkflowId,
     addConnectorToWorkflow: addConnectorToWorkflow,
     saveConnector: saveConnector,
-    deleteConnector: deleteConnector
+    deleteConnector: deleteConnector,
+    executeConnector: executeConnector,
   };
 }(
   require('mongoose'),
   require('q'),
+  require('underscore'),
   require('./resources/Workflow'),
-  require('./resources/Connector')
+  require('./resources/Connector'),
+  require('./mapper')
 ));

--- a/server/connector.js
+++ b/server/connector.js
@@ -111,13 +111,12 @@
     return function(callFrom) {
       if(callFrom) {
         var connector = null;
-
         for (var i = 0; i < workflow.connectors.length; i++) {
           connector = workflow.connectors[i];
           var result = callResults[connector.source.toString()];
           if(!!result && connector.destination.toString() === callTo.id.toString()) {
             var mappedValues = mapper.map(result.response, connector.mapper);
-            modifyCall(callTo, mappedValues);
+            callTo = modifyCall(callTo, mappedValues);
           }
         }
       }
@@ -136,15 +135,25 @@
           break;
 
         case 'header':
-          var obj = {};
-          obj[mappedValue.destination] = mappedValue.value;
+          var additonalHeaders = {};
+          additonalHeaders[mappedValue.destination] = mappedValue.value;
           if(!call.headers) {
             call.headers = {};
           }
-          call.headers = _.extend(call.headers, obj);
+          call.headers = _.extend(call.headers, additonalHeaders);
+          break;
+
+        case 'data':
+          var additionalData = mapper.createObjectFromMap(mappedValue.destination, mappedValue.value);
+          if(!call.data) {
+            call.data = {};
+          }
+          call.data = _.extend(call.data, additionalData);
           break;
       }
     }
+
+    return call;
   }
 
   module.exports = {

--- a/server/getConfig.js
+++ b/server/getConfig.js
@@ -33,8 +33,11 @@
   }
 
   function getCertificates() {
+    if(!!certificates[0]) {
       return certificates;
     }
+    return null;
+  }
 
   function getSSLConfig() {
     return config.server.strictSSL;

--- a/server/getConfig.js
+++ b/server/getConfig.js
@@ -33,12 +33,17 @@
   }
 
   function getCertificates() {
-    return certificates;
+      return certificates;
+    }
+
+  function getSSLConfig() {
+    return config.server.strictSSL;
   }
 
   module.exports = {
     getMongoConfig: getMongoConfig,
     getServerConfig: getServerConfig,
-    getCertificates: getCertificates
+    getCertificates: getCertificates,
+    getSSLConfig: getSSLConfig
   };
 }(require('fs')));

--- a/server/getConfig.js
+++ b/server/getConfig.js
@@ -15,6 +15,9 @@
     return ca;
   });
 
+  // Return config of mongo connection
+  // Default: Environment variable
+  // Fallback: config.json
   function getMongoConfig() {
     var connection = {};
     if (process.env.MONGO_CONNECTION) {
@@ -25,6 +28,9 @@
     return connection;
   }
 
+  // Return server configuration
+  // Default: App port in environment variable + config.json
+  // Fallback: config.json
   function getServerConfig() {
     if (process.env.CON_REST_PORT) {
       config.server.port = process.env.CON_REST_PORT;
@@ -32,6 +38,8 @@
     return config.server;
   }
 
+  // Returns an array of certificates,
+  // If no certificate could be loaded it returns null
   function getCertificates() {
     if(!!certificates[0]) {
       return certificates;
@@ -39,6 +47,8 @@
     return null;
   }
 
+  // Returns value for strictSSL from config.json.
+  // Should be set to false if insecure connections are allowed
   function getSSLConfig() {
     return config.server.strictSSL;
   }

--- a/server/mapper.js
+++ b/server/mapper.js
@@ -48,6 +48,36 @@
     return currentPointer;
   }
 
+  // will create an object which you can parse through the singleMap function
+  function createObjectFromMap(map, value) {
+    map = map.replace(/\]/g, '').replace(/\[/g, '.');
+
+    var obj = {};
+    var parts = map.split('.');
+    for (var i = parts.length -1; i >= 0; i--) {
+      var part = parts[i];
+
+      var newObj = {};
+      //create indexed array if part is numeric
+      if(!isNaN(part)) {
+        newObj = [];
+        part = parseInt(part, 10);
+      }
+
+
+      // the deepest key holds the value
+      if(i === parts.length - 1) {
+        newObj[part] = value;
+      } else {
+        newObj[part] = obj;
+      }
+      obj = newObj;
+    }
+
+    return obj;
+
+  }
+
   function map(obj, mapper) {
     var mappedValues = [];
     for (var i = 0; i < mapper.maps.length; i++) {
@@ -71,7 +101,8 @@
     saveMapper: saveMapper,
     createMapper: createMapper,
     deleteMapper: deleteMapper,
-    map: map
+    map: map,
+    createObjectFromMap: createObjectFromMap
   };
 }(require('mongoose'),
   require('q'),

--- a/server/mapper.js
+++ b/server/mapper.js
@@ -48,13 +48,18 @@
     return currentPointer;
   }
 
-  function map(obj, maps) {
-    var mappedValues = {};
-    for (var i = 0; i < maps.length; i++) {
-      var _map = maps[i];
+  function map(obj, mapper) {
+    var mappedValues = [];
+    for (var i = 0; i < mapper.maps.length; i++) {
+      var _map = mapper.maps[i];
 
       var value = singleMap(obj, _map.source);
-      mappedValues[_map.destination] = value;
+      mappedValues.push({
+        place: _map.place,
+        source: _map.source,
+        destination: _map.destination,
+        value: value
+      });
     }
 
     return mappedValues;

--- a/server/mapper.js
+++ b/server/mapper.js
@@ -54,19 +54,19 @@
 
     var obj = {};
     var parts = map.split('.');
-    for (var i = parts.length -1; i >= 0; i--) {
+    for (var i = parts.length - 1; i >= 0; i--) {
       var part = parts[i];
 
       var newObj = {};
       //create indexed array if part is numeric
-      if(!isNaN(part)) {
+      if (!isNaN(part)) {
         newObj = [];
         part = parseInt(part, 10);
       }
 
 
       // the deepest key holds the value
-      if(i === parts.length - 1) {
+      if (i === parts.length - 1) {
         newObj[part] = value;
       } else {
         newObj[part] = obj;
@@ -98,7 +98,7 @@
   function modifyCall(call, mappedValues) {
     for (var i = 0; i < mappedValues.length; i++) {
       var mappedValue = mappedValues[i];
-      switch(mappedValue.place) {
+      switch (mappedValue.place) {
         case 'url':
           var regex = new RegExp(mappedValue.destination, 'g');
           var url = call.url.replace(regex, mappedValue.value);
@@ -109,13 +109,13 @@
         case 'header':
           var additionalData = createObjectFromMap(mappedValue.destination, mappedValue.value);
 
-          if(mappedValue.place === 'data') {
-            if(!!!call.data) {
+          if (mappedValue.place === 'data') {
+            if (!!!call.data) {
               call.data = {};
             }
             call.data = _.extend(call.data, additionalData);
           } else {
-            if(!!!call.headers) {
+            if (!!!call.headers) {
               call.headers = {};
             }
             call.headers = _.extend(call.headers, additionalData);

--- a/server/mapper.js
+++ b/server/mapper.js
@@ -3,7 +3,7 @@
 //
 // Author: Dominik Kukacka
 // Fork me on Github: https://github.com/EnoF/con-rest
-(function mapperScope(mongoose, queue, Mapper) {
+(function mapperScope(mongoose, queue, _, Mapper) {
   'use strict';
 
   var helper = require('./serverHelper');
@@ -95,6 +95,38 @@
     return mappedValues;
   }
 
+  function modifyCall(call, mappedValues) {
+    for (var i = 0; i < mappedValues.length; i++) {
+      var mappedValue = mappedValues[i];
+      switch(mappedValue.place) {
+        case 'url':
+          var regex = new RegExp(mappedValue.destination, 'g');
+          var url = call.url.replace(regex, mappedValue.value);
+          call.url = url;
+          break;
+
+        case 'data':
+        case 'header':
+          var additionalData = createObjectFromMap(mappedValue.destination, mappedValue.value);
+
+          if(mappedValue.place === 'data') {
+            if(!!!call.data) {
+              call.data = {};
+            }
+            call.data = _.extend(call.data, additionalData);
+          } else {
+            if(!!!call.headers) {
+              call.headers = {};
+            }
+            call.headers = _.extend(call.headers, additionalData);
+          }
+          break;
+      }
+    }
+
+    return call;
+  }
+
   module.exports = {
     getMappers: getMappers,
     getMapperById: getMapperById,
@@ -102,9 +134,11 @@
     createMapper: createMapper,
     deleteMapper: deleteMapper,
     map: map,
-    createObjectFromMap: createObjectFromMap
+    createObjectFromMap: createObjectFromMap,
+    modifyCall: modifyCall,
   };
 }(require('mongoose'),
   require('q'),
+  require('underscore'),
   require('./resources/Mapper')
 ));

--- a/server/resources/Execution.js
+++ b/server/resources/Execution.js
@@ -18,6 +18,7 @@
       ref: 'APICall'
     },
     statusCode: Number,
+    url: String,
     response: Schema.Types.Mixed,
     headers: Schema.Types.Mixed,
     formData: Schema.Types.Mixed,

--- a/server/resources/Execution.js
+++ b/server/resources/Execution.js
@@ -21,7 +21,7 @@
     url: String,
     response: Schema.Types.Mixed,
     headers: Schema.Types.Mixed,
-    formData: Schema.Types.Mixed,
+    data: Schema.Types.Mixed,
     payload: Schema.Types.Mixed,
     executedAt: Date
   });

--- a/server/resources/Mapper.js
+++ b/server/resources/Mapper.js
@@ -11,9 +11,18 @@
   var mapperSchema = new Schema({
     name: String,
     maps: [{
-      place: String,
-      source: String,
-      destination: String
+      place: {
+        type: String,
+        required: true
+      },
+      source: {
+        type: String,
+        required: true
+      },
+      destination: {
+        type: String,
+        required: true
+      }
     }]
   });
 

--- a/server/resources/Mapper.js
+++ b/server/resources/Mapper.js
@@ -11,6 +11,7 @@
   var mapperSchema = new Schema({
     name: String,
     maps: [{
+      place: String,
       source: String,
       destination: String
     }]

--- a/server/server.js
+++ b/server/server.js
@@ -3,7 +3,8 @@
 //
 // Author: Andy Tang
 // Fork me on Github: https://github.com/EnoF/con-rest
-(function serverScope(express, bodyParser, api, workflow, mongoose, params, execution, workflowExecution, connector, config,
+(function serverScope(express, bodyParser, api, workflow, mongoose, params, execution, workflowExecution, connector,
+  config,
   mapper) {
   'use strict';
 
@@ -17,7 +18,7 @@
   mongoose.connect(connect.uri, connect.options);
 
   var db = mongoose.connection;
-  db.on('error', console.error);
+  db.on('error', console.log);
   db.once('open', function initiateServer() {
     app.param('id', String);
 

--- a/server/workflow.js
+++ b/server/workflow.js
@@ -3,7 +3,7 @@
 //
 // Author: Andy Tang
 // Fork me on Github: https://github.com/EnoF/con-rest
-(function workflowScope(mongoose, queue, api, connector, Workflow, Connector, WorkflowExecution, Execution, APICall) {
+(function workflowScope(mongoose, queue, api, connector, Workflow, WorkflowExecution, Execution, APICall) {
   'use strict';
 
   var helper = require('./serverHelper');
@@ -71,7 +71,7 @@
 
           apiCallQueue = apiCallQueue
             .then(connector.executeConnector(workflow, call, callResults))
-            .then(executeApiCallPromise())
+            .then(api.executeAPICall)
             .then(registerAPICallExecution(queue, callIndex, callResults));
         }
         return apiCallQueue;
@@ -91,13 +91,6 @@
         }
         throw err;
       });
-  }
-
-
-  function executeApiCallPromise() {
-    return function promise(call) {
-      return api.executeAPICall(call);
-    };
   }
 
   function saveExecutions(workflow, callResults, results) {
@@ -166,7 +159,6 @@
   require('./api.js'),
   require('./connector.js'),
   require('./resources/Workflow'),
-  require('./resources/Connector'),
   require('./resources/WorkflowExecution'),
   require('./resources/Execution'),
   require('./resources/APICall')

--- a/server/workflow.js
+++ b/server/workflow.js
@@ -86,7 +86,8 @@
             res.send(results);
           });
       }, function error(err) {
-        if(res.status) {
+        if (res.status) {
+          console.log(err.toString());
           res.status(500).send(err.toString());
         }
         throw err;

--- a/test/unit/app/viewModels/mapperCSpecs.js
+++ b/test/unit/app/viewModels/mapperCSpecs.js
@@ -21,6 +21,7 @@
       // given
       $scope.name = 'newMap';
       $scope.maps = [{
+        place: 'banana',
         source: 'foo',
         destionation: 'bar'
       }];
@@ -38,6 +39,7 @@
       // then
       expect($scope.name).toEqual(null);
       expect($scope.maps).toEqual([{
+        place: null,
         source: null,
         destination: null
       }]);

--- a/test/unit/app/viewModels/mapperCSpecs.js
+++ b/test/unit/app/viewModels/mapperCSpecs.js
@@ -23,7 +23,7 @@
       $scope.maps = [{
         place: 'banana',
         source: 'foo',
-        destionation: 'bar'
+        destination: 'bar'
       }];
 
       // predict

--- a/test/unit/app/widgets/mapperRegistratorWidgetSpecs.js
+++ b/test/unit/app/widgets/mapperRegistratorWidgetSpecs.js
@@ -2,13 +2,14 @@
   'use strict';
 
   describe('<mapper-registrator> specs', function mapperRegistratorSpecs() {
-    var testGlobals, parentScope;
+    var testGlobals, parentScope, $httpBackend;
 
     beforeEach(module('con-rest-test'));
 
     beforeEach(inject(function setupTest(testSetup) {
       testGlobals = testSetup.setupDirectiveTest();
       parentScope = testGlobals.parentScope;
+      $httpBackend = testGlobals.$httpBackend;
     }));
 
     it('should add a default map to the maps', defaultMap);
@@ -28,13 +29,16 @@
       return $scope;
     }
 
-    it('should automatically add a new map', function autoAdd() {
+    it('should automatically add a new map', autoAdd);
+
+    function autoAdd() {
       // given
       var $scope = defaultMap();
 
       // when
-      $scope.maps[0].source = 'something';
-      $scope.maps[0].destination = 'something';
+      $scope.maps[0].place = 'data';
+      $scope.maps[0].source = 'foo';
+      $scope.maps[0].destination = 'bar';
       expect($scope.maps.length).toEqual(1);
       $scope.$digest();
 
@@ -43,6 +47,32 @@
         source: null,
         destination: null
       }));
+      expect($scope.maps.length).toEqual(2);
+      return $scope;
+    }
+
+    it('should only submit the filled in maps', function filledInMaps() {
+      // given
+      var $scope = autoAdd();
+      $scope.name = 'test';
+
+      // predict
+      $httpBackend.expect('POST', '/api/mappers/', {
+          name: 'test',
+          maps: [{
+            place: 'data',
+            source: 'foo',
+            destination: 'bar'
+          }]
+        })
+        .respond(200, 'ok');
+
+      // when
+      $scope.save();
+      $httpBackend.flush();
+
+      // then
+      expect($scope.maps.length).toEqual(1);
     });
   });
 }(window.angular));

--- a/test/unit/server/connectorSpecs.js
+++ b/test/unit/server/connectorSpecs.js
@@ -161,7 +161,6 @@
           return connector.saveConnector(req, res);
         }).
         then(function then(data) {
-          // console.log(data);
           res.send.calledOnce.should.be.true;
         }).
         then(function when() {

--- a/test/unit/server/connectorSpecs.js
+++ b/test/unit/server/connectorSpecs.js
@@ -32,7 +32,7 @@
         then(function given() {
           req = {
             params: {
-              workflowId: '545726928469e940235ce700',
+              workflowId: '545726928469e940235ce701',
               connectorId: '545726928469e940235d0001'
             }
           };
@@ -59,7 +59,7 @@
         then(function given() {
           req = {
             params: {
-              workflowId: '545726928469e940235ce700'
+              workflowId: '545726928469e940235ce701'
             }
           };
           res = {};
@@ -120,7 +120,7 @@
               mapper: '5464b1e2f8243a3c321a0001'
             },
             params: {
-              workflowId: '545726928469e940235ce700'
+              workflowId: '545726928469e940235ce701'
             }
           };
           res = {};
@@ -150,7 +150,7 @@
               mapper: '5464b1e2f8243a3c321a0002'
             },
             params: {
-              workflowId: '545726928469e940235ce700',
+              workflowId: '545726928469e940235ce701',
               connectorId: '545726928469e940235d0003'
             }
           };
@@ -189,7 +189,7 @@
         then(function given() {
           req = {
             params: {
-              workflowId: '545726928469e940235ce700',
+              workflowId: '545726928469e940235ce701',
               connectorId: '545726928469e940235d0002'
             }
           };

--- a/test/unit/server/mapperSpecs.js
+++ b/test/unit/server/mapperSpecs.js
@@ -309,6 +309,56 @@
       });
     });
 
+
+    describe('createObjectFromMap', function mapScope() {
+      it('should create a valid object', function testMap(done) {
+
+        var result = mapper.createObjectFromMap('a.b.c', 'd');
+        expect(result).to.deep.equal({
+          a: {
+            b: {
+              c: 'd'
+            }
+          }
+        });
+        done();
+      });
+
+      it('should create a valid object with array', function testMap(done) {
+
+        var result = mapper.createObjectFromMap('a.b[0]', 'c');
+        expect(result).to.deep.equal({
+          a: {
+            b: [
+              'c'
+            ]
+          }
+        });
+
+
+        done();
+      });
+
+      it('should create a valid object with nested array', function testMap(done) {
+
+        var result = mapper.createObjectFromMap('a[0][0][1].b', 1337);
+        expect(result).to.deep.equal({
+          a: [
+            [
+              [
+                ,
+                {
+                  b: 1337
+                }
+              ]
+            ]
+          ]
+        });
+
+        done();
+      });
+    });
+
   });
 }(
   require('sinon'),

--- a/test/unit/server/mapperSpecs.js
+++ b/test/unit/server/mapperSpecs.js
@@ -83,6 +83,7 @@
             body: {
               name: 'fake mapper',
               maps: [{
+                place: 'data',
                 source: 'test.data',
                 destination: 'testData'
               }]
@@ -345,12 +346,9 @@
         expect(result).to.deep.equal({
           a: [
             [
-              [
-                ,
-                {
-                  b: 1337
-                }
-              ]
+              [, {
+                b: 1337
+              }]
             ]
           ]
         });

--- a/test/unit/server/mapperSpecs.js
+++ b/test/unit/server/mapperSpecs.js
@@ -212,52 +212,97 @@
         };
 
         var testMaps = [{
+          place: 'url',
           source: 'foobar',
           destination: 'rootValue'
         }, {
+          place: 'url',
           source: 'ba.na',
           destination: 'bananaObj'
         }, {
+          place: 'url',
           source: 'ba.na.na',
           destination: 'bananaValue'
         }, {
+          place: 'url',
           source: 'testArray[1]',
           destination: 'arrayValue'
         }, {
+          place: 'url',
           source: 'testArray[2].test',
           destination: 'arrayObj'
         }, {
+          place: 'url',
           source: 'users[0].groups[0].name',
           destination: 'complexString'
         }, {
+          place: 'url',
           source: 'users[0].groups',
           destination: 'complexArray'
         }, {
+          place: 'url',
           source: 'arr[0][1][0]',
           destination: 'arrayArray'
         }, {
+          place: 'url',
           source: 'users[0].email',
           destination: 'noValue'
         }];
 
-        var testOutput = {
-          rootValue: 123,
-          bananaObj: {
-            na: 1337
-          },
-          bananaValue: 1337,
-          arrayValue: 'apple',
-          arrayObj: 'orange',
-          complexString: 'admin',
-          complexArray: [{
-            name: 'admin'
-          }],
-          arrayArray: 'baz',
-          noValue: undefined
-        };
+        var testOutput = [{
+          place: 'url',
+          source: 'foobar',
+          destination: 'rootValue',
+          value: 123
+        }, {
+          destination: 'bananaObj',
+          place: 'url',
+          source: 'ba.na',
+          value: {
+            'na': 1337,
+          }
+        }, {
+          destination: 'bananaValue',
+          place: 'url',
+          source: 'ba.na.na',
+          value: 1337
+        }, {
+          destination: 'arrayValue',
+          place: 'url',
+          source: 'testArray[1]',
+          value: 'apple',
+        }, {
+          destination: 'arrayObj',
+          place: 'url',
+          source: 'testArray[2].test',
+          value: 'orange',
+        }, {
+          destination: 'complexString',
+          place: 'url',
+          source: 'users[0].groups[0].name',
+          value: 'admin',
+        }, {
+          destination: 'complexArray',
+          place: 'url',
+          source: 'users[0].groups',
+          value: [{
+            'name': 'admin',
+          }]
+        }, {
+          destination: 'arrayArray',
+          place: 'url',
+          source: 'arr[0][1][0]',
+          value: 'baz',
+        }, {
+          destination: 'noValue',
+          place: 'url',
+          source: 'users[0].email',
+          value: undefined,
+        }];
 
-
-        var result = mapper.map(testObject, testMaps);
+        var result = mapper.map(testObject, {
+          maps: testMaps
+        });
         expect(result).to.deep.equal(testOutput);
 
         done();

--- a/test/unit/server/mocks.js
+++ b/test/unit/server/mocks.js
@@ -99,6 +99,16 @@
       destination: '545726928469e940235ce773',
       mapper: '5464b1e2f8243a3c321a0004'
     }]
+  }, {
+    _id: '545726928469e940235ce702',
+    name: 'fourthWorkflow (dconenctor data)',
+    calls: ['545726928469e940235ce770', '545726928469e940235ce900'],
+    connectors: [{
+      _id: '545726928469e940235e0001',
+      source: '545726928469e940235ce770',
+      destination: '545726928469e940235ce900',
+      mapper: '5464b1e2f8243a3c321a0005'
+    }]
   }];
 
   var workflowExecutions = [{
@@ -193,6 +203,23 @@
         source: 'path.to.follow[0]',
         destination: 'testValue'
       }]
+    },
+    {
+      _id: '5464b1e2f8243a3c321a0005',
+      name: 'post mapper',
+      maps: [{
+        place: 'data',
+        source: 'origin',
+        destination: 'rootTest'
+      },{
+        place: 'data',
+        source: 'origin',
+        destination: 'obj.test'
+      },{
+        place: 'data',
+        source: 'origin',
+        destination: 'array[0]'
+      }]
     }
   ];
 
@@ -201,7 +228,6 @@
     var allPromisses = [];
     var Model = mongoose.model(model);
     var Connector = mongoose.model('Connector');
-    // console.log(Model.modelName, Object.keys(Model.schema.tree).join(', '));
 
     for (var i = 0; i < mocks.length; i++) {
       var data = mocks[i];
@@ -213,8 +239,8 @@
 
       var newModel = new Model(data);
       if (model === 'Workflow' && connectors && connectors.length > 0) {
-        for (var i = 0; i < connectors.length; i++) {
-          var connector = connectors[i];
+        for (var n = 0; n < connectors.length; n++) {
+          var connector = connectors[n];
           newModel.connectors.push(connector);
         };
 

--- a/test/unit/server/mocks.js
+++ b/test/unit/server/mocks.js
@@ -37,6 +37,11 @@
       headers: {
         'user-agent': 'TestUserAgent'
       }
+    }, {
+      _id: '545726928469e940235ce773',
+      name: 'queue call #3',
+      url: 'http://httpbin.org/get?testKey=testValue',
+      method: 'GET'
     },
 
     {
@@ -67,26 +72,32 @@
   var workflows = [{
     _id: '545726928469e940235ce769',
     name: 'firstWorkflow',
-    calls: ['545726928469e940235ce769', '545726928469e940235ce770']
+    calls: ['545726928469e940235ce769', '545726928469e940235ce770'],
+    connectors: []
   }, {
     _id: '545726928469e940235ce700',
     name: 'secondWorkflow',
     calls: ['545726928469e940235ce770', '545726928469e940235ce771', '545726928469e940235ce772'],
+    connectors: []
+  }, {
+    _id: '545726928469e940235ce701',
+    name: 'thirdWorkflow (connectors)',
+    calls: ['545726928469e940235ce770', '545726928469e940235ce771', '545726928469e940235ce773'],
     connectors: [{
       _id: '545726928469e940235d0001',
       source: '545726928469e940235ce770',
       destination: '545726928469e940235ce771',
-      mapper: '5464b1e2f8243a3c321a0001'
+      mapper: '5464b1e2f8243a3c321a0003'
     }, {
       _id: '545726928469e940235d0002',
-      source: '545726928469e940235ce771',
-      destination: '545726928469e940235ce772',
-      mapper: '5464b1e2f8243a3c321a0001'
+      source: '545726928469e940235ce770',
+      destination: '545726928469e940235ce773',
+      mapper: '5464b1e2f8243a3c321a0003'
     }, {
       _id: '545726928469e940235d0003',
-      source: '545726928469e940235ce770',
-      destination: '545726928469e940235ce772',
-      mapper: '5464b1e2f8243a3c321a0001'
+      source: '545726928469e940235ce771',
+      destination: '545726928469e940235ce773',
+      mapper: '5464b1e2f8243a3c321a0004'
     }]
   }];
 
@@ -147,9 +158,11 @@
       _id: '5464b1e2f8243a3c321a0001',
       name: 'extractor for banana and userid',
       maps: [{
+        place: 'body',
         source: 'user.id',
         destination: 'ba.na.na'
       }, {
+        place: 'body',
         source: 'user.name',
         destination: 'userName'
       }]
@@ -158,8 +171,27 @@
       _id: '5464b1e2f8243a3c321a0002',
       name: 'overwriter',
       maps: [{
+        place: 'body',
         source: 'matha',
         destination: 'faka'
+      }]
+    },
+    {
+      _id: '5464b1e2f8243a3c321a0003',
+      name: 'against mock #1',
+      maps: [{
+        place: 'header',
+        source: 'indicator',
+        destination: 'x-indicator'
+      }]
+    },
+    {
+      _id: '5464b1e2f8243a3c321a0004',
+      name: 'against mock #2',
+      maps: [{
+        place: 'url',
+        source: 'path.to.follow[0]',
+        destination: 'testValue'
       }]
     }
   ];
@@ -174,13 +206,13 @@
     for (var i = 0; i < mocks.length; i++) {
       var data = mocks[i];
       var deferred = queue.defer();
-      if (model === 'Workflow') {
+      if (model === 'Workflow' && data.connectors && data.connectors.length > 0) {
         var connectors = data.connectors || [];
         delete data.connectors;
       }
 
       var newModel = new Model(data);
-      if (model === 'Workflow') {
+      if (model === 'Workflow' && connectors && connectors.length > 0) {
         for (var i = 0; i < connectors.length; i++) {
           var connector = connectors[i];
           newModel.connectors.push(connector);

--- a/test/unit/server/workflowSpecs.js
+++ b/test/unit/server/workflowSpecs.js
@@ -27,28 +27,28 @@
       it('should return all the registered workflows', function getRegisteredWorkflows(done) {
         var req;
         var res;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {};
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.getWorkflows(req, res);
-        }).
-        then(function then(workflows) {
+        })
+        .then(function then(workflows) {
           workflows.length.should.be.above(0);
           res.send.args[0][0].length.should.be.above(0);
-        }).
-        then(done).
-        catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
 
       it('should return a workflow based on id', function getRegisteredWorkflowById(done) {
         var req;
         var res;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             params: {
               id: '545726928469e940235ce769'
@@ -56,17 +56,17 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.getWorkflowById(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
           var call = res.send.args[0][0];
           call.name.should.be.exactly('firstWorkflow');
           call.calls.length.should.be.exactly(2);
-        }).
-        then(done).
-        catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
     });
 
@@ -74,8 +74,8 @@
       it('should register an new workflow', function registerWorkflow(done) {
         var req;
         var res;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             body: {
               name: 'fakeCall',
@@ -84,23 +84,23 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.registerWorkflow(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
           res.send.calledOnce.should.be.true;
           res.send.args[0][0].should.be.a.String;
-        }).
-        then(done).
-        catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
 
       it('should overwrite an existing workflow', function saveExistingWorkflow(done) {
         var req;
         var res;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             body: {
               name: 'overwritten',
@@ -112,24 +112,24 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.saveWorkflow(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
           res.send.calledOnce.should.be.true;
           res.send.args[0][0].should.be.a.String;
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.getWorkflowById(req, {
             send: sinon.stub()
           });
-        }).
-        then(function then(workflow) {
+        })
+        .then(function then(workflow) {
           workflow.name.should.be.exactly('overwritten');
-        }).
-        then(done).
-        catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
     });
 
@@ -137,8 +137,8 @@
       it('should delete an existing workflow', function saveExistingWorkflow(done) {
         var req;
         var res;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             params: {
               id: '545726928469e940235ce769'
@@ -146,24 +146,24 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.deleteWorkflow(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
           res.send.calledOnce.should.be.true;
           res.send.args[0][0].should.be.a.String;
-        }).
-        then(function when() {
+        })
+        .then(function when() {
           return workflow.getWorkflowById(req, {
             send: sinon.stub()
           });
-        }).
-        then(function then(workflow) {
+        })
+        .then(function then(workflow) {
           (workflow === null).should.be.true;
-        }).
-        then(done).
-        catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
     });
 
@@ -181,8 +181,8 @@
         var req;
         var res;
         var startCount = 0;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             params: {
               id: '545726928469e940235ce700'
@@ -190,15 +190,15 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function() {
+        })
+        .then(function() {
           return Execution.count().exec();
-        }).
-        then(function when(count) {
+        })
+        .then(function when(count) {
           startCount = count;
           return workflow.executeWorkflowById(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
 
           var call = res.send.args[0][0];
           Object.keys(call).length.should.be.exactly(3);
@@ -220,9 +220,9 @@
             endCount.should.be.exactly(startCount + 3);
           });
 
-        }).
-        then(done).
-        catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
 
       it('should execute a workflow with connectors', function getRegisteredWorkflows(done) {
@@ -262,8 +262,8 @@
         var req;
         var res;
         var startCount = 0;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             params: {
               id: '545726928469e940235ce701'
@@ -271,15 +271,15 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function() {
+        })
+        .then(function() {
           return Execution.count().exec();
-        }).
-        then(function when(count) {
+        })
+        .then(function when(count) {
           startCount = count;
           return workflow.executeWorkflowById(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
 
           var call = res.send.args[0][0];
           Object.keys(call).length.should.be.exactly(3);
@@ -335,29 +335,31 @@
             endCount.should.be.exactly(startCount + 3);
           });
 
-        }).then(done).catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
       it('should execute a workflow with connectors (data)', function getRegisteredWorkflows(done) {
 
-        nock('http://httpbin.org').
-        get('/get').
-        reply(200, {
+        nock('http://httpbin.org')
+        .get('/get')
+        .reply(200, {
           origin: '10.10.10.10',
           url: 'http://httpbin.org/get'
         });
 
-        nock('http://httpbin.org').
-        filteringRequestBody(function(path) {
+        nock('http://httpbin.org')
+        .filteringRequestBody(function(path) {
           return 'foobar';
-        }).
-        post('/post', 'foobar').
-        reply(200);
+        })
+        .post('/post', 'foobar')
+        .reply(200);
 
         var req;
         var res;
         var startCount = 0;
-        queue().
-        then(function given() {
+        queue()
+        .then(function given() {
           req = {
             params: {
               id: '545726928469e940235ce702'
@@ -365,15 +367,15 @@
           };
           res = {};
           res.send = sinon.spy();
-        }).
-        then(function() {
+        })
+        .then(function() {
           return Execution.count().exec();
-        }).
-        then(function when(count) {
+        })
+        .then(function when(count) {
           startCount = count;
           return workflow.executeWorkflowById(req, res);
-        }).
-        then(function then() {
+        })
+        .then(function then() {
           var response = res.send.args[0][0][1];
 
           expect(response.data).to.deep.equal({
@@ -391,7 +393,9 @@
             expect(endCount).to.equal(startCount + 2);
           });
 
-        }).then(done).catch(done);
+        })
+        .then(done)
+        .catch(done);
       });
     });
   });


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-72205118%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-72477163%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-73001763%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-73023150%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-73023183%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-73023210%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23827829%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23827890%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828068%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828272%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828395%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828473%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828490%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828533%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830311%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830363%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830383%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830454%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830483%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830493%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23830866%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843578%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843579%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843580%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843581%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843582%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843583%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843584%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23843585%22%2C%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r24084710%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23issuecomment-72205118%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22code%20review%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Found%20a%20bug%20on%20mapper%20creation.%20This%20blocks%20testing%20the%20connectors.%20%5Cr%5Cn%60%60%60%5Cr%5CnScenario%3A%20Create%20mapper%5Cr%5Cn%20%20Given%20Mapper%20name%20is%20%5C%22test%5C%22%5Cr%5Cn%20%20%20%20And%20place%20is%20%5C%22data%5C%22%5Cr%5Cn%20%20%20%20And%20source%20is%20%5C%22authToken%5C%22%5Cr%5Cn%20%20%20%20And%20source%20is%20%5C%22authToken%5C%22%5Cr%5Cn%20%20When%20pressing%20the%20save%20button%5Cr%5Cn%20%20Then%20a%20mapper%20should%20be%20present%20with%20one%20map%5Cr%5Cn%20%20%5Cr%5Cn%20%20Error%3A%20Mapper%20with%20one%20map%20corresponding%20provided%20data%20is%20present%5Cr%5Cn%20%20%20%20%20along%20with%20a%20map%20with%20empty%20values%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-02-02T15%3A36%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40TheBay0r%20I%27d%20want%20to%20merge%20this%20pull%20request%20with%20an%20open%20issue%20if%20you%20tested%20OK%20the%20%60data%60%20and%20%60header%60%20mapping.%20Otherwise%20the%20PR%20gets%20too%20big%20and%20difficult%20to%20follow.%20%22%2C%20%22created_at%22%3A%20%222015-02-05T06%3A42%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20rest%20seems%20to%20be%20fine.%20We%20can%20change%20the%20behaviour%20in%20an%20future%20pull%20request%20anyways%22%2C%20%22created_at%22%3A%20%222015-02-05T10%3A13%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8627051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TheBay0r%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-02-05T10%3A13%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8627051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TheBay0r%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-02-05T10%3A14%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8627051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TheBay0r%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/connector.js%2041%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828272%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20the%20%60header%60%20mapped%20differently%20then%20the%20%60data%60%3F%20Aren%27t%20they%20both%20a%20%60json%60%3F%22%2C%20%22created_at%22%3A%20%222015-01-30T07%3A56%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%20they%20are.%20However%20the%20%60header%60cannot%20contain%20nested%20objects%20only%20key/value%20pairs%20%28value%20has%20to%20be%20a%20string%29.%5Cr%5Cn%60data%60%20on%20the%20other%20side%20can%20be%20nested%20objects%2C%20arrays%20whatever%20you%20like%20it%20to%20be.%5Cr%5Cn%5Cr%5Cndoes%20it%20make%20sense%20to%20use%20the%20same%20function%20for%20it%3F%22%2C%20%22created_at%22%3A%20%222015-01-30T09%3A00%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/connector.js%3AL107-175%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/workflow.js%2042%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828490%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Then%20we%20could%20remove%20this%20wrapper%20function%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A03%3A37Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22yes%2C%20i%20will%20do%20that.%22%2C%20%22created_at%22%3A%20%222015-01-30T09%3A01%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/workflow.js%3AL86-102%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20test/unit/server/workflowSpecs.js%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828533%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22would%20you%20be%20so%20kind%20and%20move%20the%20%60.%60%20to%20the%20next%20line%3F%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A04%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22ah%20yes%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-01-30T09%3A01%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20test/unit/server/workflowSpecs.js%3AL224-405%22%7D%2C%20%22Pull%200ce5f088024cc7f8ee705c105f9bfa98b5400a9d%20server/mapper.js%2073%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r24084710%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22See%20Bug%20%2371%20%22%2C%20%22created_at%22%3A%20%222015-02-04T14%3A09%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8627051%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/TheBay0r%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/mapper.js%3AL48-145%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/connector.js%2022%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23827890%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22basically%20%60callTo%60%20is%20the%20call%20input%20right%3F%20I%20think%20it%20would%20be%20easier%20to%20understand%20if%20we%20rename%20this%20to%20%60callInput%60%22%2C%20%22created_at%22%3A%20%222015-01-30T07%3A44%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22callTo%20is%20the%20next%20call%20which%20will%20be%20executed%20so%20probably%20%60nextCall%60%20would%20be%20more%20appropriate%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A58%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/connector.js%3AL107-175%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/connector.js%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828068%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20understand%20why%202%20of%203%20cases%20are%20handled%20in%20the%20connector%2C%20while%20they%20are%20actually%20mapping%20values.%20From%20my%20point%20of%20view%20this%20should%20be%20the%20responsibility%20of%20the%20mapper.%20In%20fact%2C%20imo%20the%20modifyCall%20should%20be%20a%20function%20completely%20in%20responsibility%20of%20the%20mapper.%20%22%2C%20%22created_at%22%3A%20%222015-01-30T07%3A49%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22Actually%20you%20are%20right%2C%20i%20will%20move%20it%20to%20the%20mapper%20since%20it%20makes%20much%20more%20sense.%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A59%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/connector.js%3AL107-175%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/connector.js%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23827829%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20recently%20started%20adding%20%60%21%21callForm%60%20to%20my%20checks%20if%20something%20gives%20a%20%60true%60%20value.%20I%20think%20it%20adds%20a%20little%20bit%20more%20readability.%20What%20do%20you%20think%3F%20%28they%20do%20the%20same%20btw%29%22%2C%20%22created_at%22%3A%20%222015-01-30T07%3A42%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22i%20think%20the%20%21%21%20makes%20it%20much%20more%20clearer%21%20i%20like%20it%20%3A%29%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A57%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/connector.js%3AL107-175%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/workflow.js%2023%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828473%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22why%20not%3A%5Cr%5Cn%60.then%28api.executeAPICall%29%60%5Cr%5Cn%5Cr%5CnThis%20will%20result%20in%20the%20same%20without%20the%20need%20of%20an%20wrapper%20function.%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A03%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/workflow.js%3AL70-78%22%7D%2C%20%22Pull%2007de42be97e81a10a34e681fc944db8d01ed31db%20server/workflow.js%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Jumio/con-rest/pull/70%23discussion_r23828395%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Since%20the%20%60connector%60%20already%20imports%20the%20%60Connector%20resource%60%2C%20we%20can%20now%20remove%20the%20Connector%20import.%5Cr%5CnThe%20same%20would%20apply%20for%20%60APIcall%60%20and%20if%20I%27m%20not%20mistaken%20also%20the%20%60Execution%60.%22%2C%20%22created_at%22%3A%20%222015-01-30T08%3A01%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%2C%20%7B%22body%22%3A%20%22with%20the%20%60Connector%60%20you%20are%20right.%5Cr%5Cnbut%20i%20use%20the%20%60Execution%60%20and%20the%20%60APICall%60%20directly%20so%20i%20need%20the%20import%20%28or%20a%20call%20to%20%60mongoose.model%60%20but%20i%20think%20this%20ways%20it%27s%20clearer%29%22%2C%20%22created_at%22%3A%20%222015-01-30T09%3A12%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/243319%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/dominikkukacka%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-01-30T14%3A03%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1508400%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/EnoF%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20server/workflow.js%3AL3-10%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/TheBay0r%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8627051%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/TheBay0r'><img src='https://avatars.githubusercontent.com/u/8627051?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 0ce5f088024cc7f8ee705c105f9bfa98b5400a9d server/mapper.js 73'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r24084710'>File: server/mapper.js:L48-145</a></b>
- <a href='https://github.com/TheBay0r'><img border=0 src='https://avatars.githubusercontent.com/u/8627051?v=3' height=16 width=16'></a> See Bug #71
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/connector.js 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23827829'>File: server/connector.js:L107-175</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> I recently started adding `!!callForm` to my checks if something gives a `true` value. I think it adds a little bit more readability. What do you think? (they do the same btw)
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> i think the !! makes it much more clearer! i like it :)
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/connector.js 22'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23827890'>File: server/connector.js:L107-175</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> basically `callTo` is the call input right? I think it would be easier to understand if we rename this to `callInput`
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> callTo is the next call which will be executed so probably `nextCall` would be more appropriate
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/connector.js 30'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23828068'>File: server/connector.js:L107-175</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> I don't understand why 2 of 3 cases are handled in the connector, while they are actually mapping values. From my point of view this should be the responsibility of the mapper. In fact, imo the modifyCall should be a function completely in responsibility of the mapper.
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> Actually you are right, i will move it to the mapper since it makes much more sense.
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/connector.js 41'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23828272'>File: server/connector.js:L107-175</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> Why is the `header` mapped differently then the `data`? Aren't they both a `json`?
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> Yes they are. However the `header`cannot contain nested objects only key/value pairs (value has to be a string).
`data` on the other side can be nested objects, arrays whatever you like it to be.
does it make sense to use the same function for it?
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/workflow.js 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23828395'>File: server/workflow.js:L3-10</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> Since the `connector` already imports the `Connector resource`, we can now remove the Connector import.
The same would apply for `APIcall` and if I'm not mistaken also the `Execution`.
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> with the `Connector` you are right.
but i use the `Execution` and the `APICall` directly so i need the import (or a call to `mongoose.model` but i think this ways it's clearer)
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/workflow.js 23'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23828473'>File: server/workflow.js:L70-78</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> why not:
`.then(api.executeAPICall)`
This will result in the same without the need of an wrapper function.
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db server/workflow.js 42'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23828490'>File: server/workflow.js:L86-102</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> Then we could remove this wrapper function :)
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> yes, i will do that.
- [x] <a href='#crh-comment-Pull 07de42be97e81a10a34e681fc944db8d01ed31db test/unit/server/workflowSpecs.js 13'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#discussion_r23828533'>File: test/unit/server/workflowSpecs.js:L224-405</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> would you be so kind and move the `.` to the next line?
- <a href='https://github.com/dominikkukacka'><img border=0 src='https://avatars.githubusercontent.com/u/243319?v=3' height=16 width=16'></a> ah yes :)
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Jumio/con-rest/pull/70#issuecomment-72205118'>General Comment</a></b>
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> code review :+1:
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> Found a bug on mapper creation. This blocks testing the connectors.
```
Scenario: Create mapper
Given Mapper name is "test"
And place is "data"
And source is "authToken"
And source is "authToken"
When pressing the save button
Then a mapper should be present with one map
Error: Mapper with one map corresponding provided data is present
along with a map with empty values
```
- <a href='https://github.com/EnoF'><img border=0 src='https://avatars.githubusercontent.com/u/1508400?v=3' height=16 width=16'></a> @TheBay0r I'd want to merge this pull request with an open issue if you tested OK the `data` and `header` mapping. Otherwise the PR gets too big and difficult to follow.
- <a href='https://github.com/TheBay0r'><img border=0 src='https://avatars.githubusercontent.com/u/8627051?v=3' height=16 width=16'></a> The rest seems to be fine. We can change the behaviour in an future pull request anyways


<a href='https://www.codereviewhub.com/Jumio/con-rest/pull/70?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/Jumio/con-rest/pull/70?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/Jumio/con-rest/pull/70?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/Jumio/con-rest/pull/70'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>